### PR TITLE
Surrounding paths with double-quote into PostBuildEvent / Out-Shellcode.ps1 compatible with PowerShell v2

### DIFF
--- a/Native/Native.vcxproj
+++ b/Native/Native.vcxproj
@@ -96,7 +96,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)bin\NativeLoader_x86.exe</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)bin\NativeLoader_x86.exe"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -113,7 +113,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)bin\NativeLoader_x64.exe</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)bin\NativeLoader_x64.exe"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -133,7 +133,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)bin\NativeLoader_x86.exe</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)bin\NativeLoader_x86.exe"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -153,7 +153,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)bin\NativeLoader_x64.exe</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)bin\NativeLoader_x64.exe"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/ShellcodeRDI/ShellcodeRDI.vcxproj
+++ b/ShellcodeRDI/ShellcodeRDI.vcxproj
@@ -218,7 +218,7 @@
       </Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)lib\PowerShell\Out-Shellcode.ps1 $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName).map $(SolutionDir)bin\$(TargetName)_x86.bin</Command>
+      <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(SolutionDir)lib\PowerShell\Out-Shellcode.ps1" "$(OutDir)$(TargetName)$(TargetExt)" "$(OutDir)$(TargetName).map" "$(SolutionDir)bin\$(TargetName)_x86.bin"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Extract position independent shellcode</Message>
@@ -382,7 +382,7 @@
       </Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)lib\PowerShell\Out-Shellcode.ps1 $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName).map $(SolutionDir)bin\$(TargetName)_x86.bin</Command>
+      <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(SolutionDir)lib\PowerShell\Out-Shellcode.ps1" "$(OutDir)$(TargetName)$(TargetExt)" "$(OutDir)$(TargetName).map" "$(SolutionDir)bin\$(TargetName)_x86.bin"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Extract position independent shellcode</Message>
@@ -737,7 +737,7 @@
       <Message>Build AdjustStack.asm</Message>
     </PreBuildEvent>
     <PostBuildEvent>
-      <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File $(SolutionDir)lib\PowerShell\Out-Shellcode.ps1 $(OutDir)$(TargetName)$(TargetExt) $(OutDir)$(TargetName).map $(SolutionDir)bin\$(TargetName)_x64.bin</Command>
+      <Command>powershell.exe -NoProfile -ExecutionPolicy Bypass -File "$(SolutionDir)lib\PowerShell\Out-Shellcode.ps1" "$(OutDir)$(TargetName)$(TargetExt)" "$(OutDir)$(TargetName).map" "$(SolutionDir)bin\$(TargetName)_x64.bin"</Command>
     </PostBuildEvent>
     <PostBuildEvent>
       <Message>Extract position independent shellcode</Message>

--- a/TestDLL/TestDLL.vcxproj
+++ b/TestDLL/TestDLL.vcxproj
@@ -95,7 +95,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)Bin\TestDLL_x86.dll</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)Bin\TestDLL_x86.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Debug|x64'">
@@ -112,7 +112,7 @@
       <GenerateDebugInformation>true</GenerateDebugInformation>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)Bin\TestDLL_x64.dll</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)Bin\TestDLL_x64.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|Win32'">
@@ -133,7 +133,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)Bin\TestDLL_x86.dll</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)Bin\TestDLL_x86.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemDefinitionGroup Condition="'$(Configuration)|$(Platform)'=='Release|x64'">
@@ -154,7 +154,7 @@
       <OptimizeReferences>true</OptimizeReferences>
     </Link>
     <PostBuildEvent>
-      <Command>copy /y $(TargetPath) $(SolutionDir)Bin\TestDLL_x64.dll</Command>
+      <Command>copy /y "$(TargetPath)" "$(SolutionDir)Bin\TestDLL_x64.dll"</Command>
     </PostBuildEvent>
   </ItemDefinitionGroup>
   <ItemGroup>

--- a/lib/PowerShell/Out-Shellcode.ps1
+++ b/lib/PowerShell/Out-Shellcode.ps1
@@ -13,6 +13,11 @@
     $OutputFile
 )
 
+# PowerShell v2
+if(!$PSScriptRoot){ 
+	$PSScriptRoot = Split-Path $MyInvocation.MyCommand.Path -Parent 
+}
+
 . "$PSScriptRoot\Get-PEHeader.ps1"
 
 $PE = Get-PEHeader $InputExe -GetSectionData


### PR DESCRIPTION
I have some directories with spaces (such as "Visual Studio"). Double quotes were added.