### PR TITLE
Python: Non-ASCII character error in pefile.py

### DIFF
--- a/Python/pefile.py
+++ b/Python/pefile.py
@@ -4762,7 +4762,7 @@ class PE:
 	# [ Microsoft Portable Executable and Common Object File Format Specification ]
 	# "The alignment factor (in bytes) that is used to align the raw data of sections in
 	#  the image file. The value should be a power of 2 between 512 and 64 K, inclusive.
-	#  The default is 512. If the SectionAlignment is less than the architecture’s page
+	#  The default is 512. If the SectionAlignment is less than the architecture's page
 	#  size, then FileAlignment must match SectionAlignment."
 	#
 	# The following is a hard-coded constant if the Windows loader


### PR DESCRIPTION
`SyntaxError: Non-ASCII character '\xe2' in file /path/to/sRDI/Python/pefile.py on line 4765.`

Replaced a fancy single-quote by its ASCII version in a python comment (seem to only affect Python2) . 