### PR TITLE
Add arguments.output_format to ConvertToShellcode.py

### DIFF
--- a/Python/ConvertToShellcode.py
+++ b/Python/ConvertToShellcode.py
@@ -11,13 +11,14 @@ def main():
     parser.add_argument('-u', '--user-data', dest='user_data', help='Data to pass to the target function', default='dave')
     parser.add_argument('-c', '--clear-header', dest='clear_header', action='store_true', help='Clear the PE header on load')
     parser.add_argument('-i', '--obfuscate-imports', dest='obfuscate_imports', action='store_true', help='Randomize import dependency load order', default=False)
-    parser.add_argument('-d', '--import-delay', dest='import_delay', help='Number of seconds to pause between loading imports', type=int, default=0)    
+    parser.add_argument('-d', '--import-delay', dest='import_delay', help='Number of seconds to pause between loading imports', type=int, default=0)
+    parser.add_argument('-of', '--output-format', dest='output_format', help='Output format of the shellcode (e.g. raw,string)', type=str, default="raw")
+    
     arguments = parser.parse_args()
 
     input_dll = arguments.input_dll
     output_bin = input_dll.replace('.dll', '.bin')
 
-    print('Creating Shellcode: {}'.format(output_bin))
     dll = open(arguments.input_dll, 'rb').read()
 
     flags = 0
@@ -29,9 +30,19 @@ def main():
         flags = flags | 0x4 | arguments.import_delay << 16
 
     converted_dll = ConvertToShellcode(dll, HashFunctionName(arguments.function_name), arguments.user_data.encode(), flags)
+    
+    if arguments.output_format=="raw":
+        print('Creating Shellcode: {}'.format(output_bin))
+        with open(output_bin, 'wb') as f:
+           f.write(converted_dll)
+    
+    elif arguments.output_format=="string":
+        output_bin = input_dll.replace('.dll', '.txt')
+        converted_dll_text ="".join([r"\x{}".format(str(format(c,'02x'))) for c in converted_dll])
 
-    with open(output_bin, 'wb') as f:
-        f.write(converted_dll)
+        print('Creating Shellcode: {}'.format(output_bin))
+        with open(output_bin, 'w') as f:
+           f.write(converted_dll_text)
 
 if __name__ == '__main__':
     main()


### PR DESCRIPTION
Added a new argument for converting the output format of the the shellcode to a string. The output string will be written to a new text file.



**Example:**

```bash
# Default (raw)
python ./sRDI/Python/ConvertToShellcode.py hello.dll
Creating Shellcode: hello.bin

# String format
python ./sRDI/Python/ConvertToShellcode.py hello.dll -of string
Creating Shellcode: hello.txt

cat hello.txt  
\xe8\x00\x00\x00\x00\x59\x49 ***
```