### PR TITLE
Fix swapped arguments

### DIFF
--- a/Python/ShellcodeRDI.py
+++ b/Python/ShellcodeRDI.py
@@ -106,17 +106,17 @@ def ConvertToShellcode(dllBytes, functionHash=0x10, userData=b'None', flags=0):
         bootstrap += b'\x48\x83\xec'
         bootstrap += b'\x30' # 32 bytes for shadow space + 16 bytes for last args
 
-        # mov qword ptr [rsp + 0x28], rcx (shellcode base) - Push in arg 5
+        # mov qword ptr [rsp + 0x20], rcx (shellcode base) - Push in arg 5
         bootstrap += b'\x48\x89\x4C\x24'
-        bootstrap += b'\x28'
+        bootstrap += b'\x20'
 
         # add rcx, <Offset of the DLL>
         bootstrap += b'\x48\x81\xc1'
         bootstrap += pack('I', dllOffset)
 
-        # mov dword ptr [rsp + 0x20], <Flags> - Push in arg 6 just above shadow space
+        # mov dword ptr [rsp + 0x28], <Flags> - Push in arg 6 just above shadow space
         bootstrap += b'\xC7\x44\x24'
-        bootstrap += b'\x20'
+        bootstrap += b'\x28'
         bootstrap += pack('I', flags)
 
         # call - Transfer execution to the RDI


### PR DESCRIPTION
There seems to be an inconsistency between the x86 and x64 stubs. The shellcodebase (arg 5) and Flags (arg 6) seem to be swapped for some reason.

This usually results in a multi-hour long delay.

The delay is caused by Flags(shellcodebase) is larger than 16 bytes: Bytes 16->32 are reserved for the `sleep` variable which is used by `Step 5: process our import table` in combination with `SRDI_OBFUSCATEIMPORTS` in the `pSleep` function.

This fix is only tested and implemented for the Python language. The other languages are still TODO. Any feedback is welcome.

Note: This is, as far as I can see, a direct fix for https://github.com/monoxgas/sRDI/issues/31