### PR TITLE
Fix swapped arguments in x64 builders

### DIFF
--- a/DotNet/Program.cs
+++ b/DotNet/Program.cs
@@ -571,12 +571,12 @@ namespace RDIShellcodeLoader
                 newShellcode.Add(0xec);
                 newShellcode.Add(6 * 8); // 32 bytes for shadow space + 8 bytes for last arg + 8 bytes for stack alignment
 
-                // mov qword ptr [rsp + 0x28], rcx (shellcode base) - Push in arg 5
+                // mov qword ptr [rsp + 0x20], rcx (shellcode base) - Push in arg 5
                 newShellcode.Add(0x48);
                 newShellcode.Add(0x89);
                 newShellcode.Add(0x4C);
                 newShellcode.Add(0x24);
-                newShellcode.Add(5 * 8);
+                newShellcode.Add(4 * 8);
 
                 // Setup the location of the DLL into RCX
                 // add rcx, <Offset of the DLL>
@@ -586,11 +586,11 @@ namespace RDIShellcodeLoader
                 foreach (byte b in BitConverter.GetBytes(dllOffset))
                     newShellcode.Add(b);
 
-                // mov dword ptr [rsp + 0x20], <Flags> - Push arg 6 just above shadow space
+                // mov dword ptr [rsp + 0x28], <Flags> - Push arg 6 just above shadow space
                 newShellcode.Add(0xc7);
                 newShellcode.Add(0x44);
                 newShellcode.Add(0x24);
-                newShellcode.Add(4 * 8);
+                newShellcode.Add(5 * 8);
                 foreach (byte b in BitConverter.GetBytes((uint)flags))
                     newShellcode.Add(b);
 

--- a/Native/Loader.cpp
+++ b/Native/Loader.cpp
@@ -181,12 +181,12 @@ BOOL ConvertToShellcode(LPVOID inBytes, DWORD length, DWORD userFunction, LPVOID
 		bootstrap[i++] = 0xec;
 		bootstrap[i++] = 6 * 8; // 32 bytes for shadow space + 16 bytes for last args
 
-		// mov qword ptr [rsp + 0x28], rcx (shellcode base) - Push in arg 5
+		// mov qword ptr [rsp + 0x20], rcx (shellcode base) - Push in arg 5
 		bootstrap[i++] = 0x48;
 		bootstrap[i++] = 0x89;
 		bootstrap[i++] = 0x4C;
 		bootstrap[i++] = 0x24;
-		bootstrap[i++] = 5 * 8;
+		bootstrap[i++] = 4 * 8;
 
 		// add rcx, <Offset of the DLL>
 		bootstrap[i++] = 0x48;
@@ -195,11 +195,11 @@ BOOL ConvertToShellcode(LPVOID inBytes, DWORD length, DWORD userFunction, LPVOID
 		MoveMemory(bootstrap + i, &dllOffset, sizeof(dllOffset));
 		i += sizeof(dllOffset);
 
-		// mov dword ptr [rsp + 0x20], <Flags> - Push arg 6 just above shadow space
+		// mov dword ptr [rsp + 0x28], <Flags> - Push arg 6 just above shadow space
 		bootstrap[i++] = 0xC7;
 		bootstrap[i++] = 0x44;
 		bootstrap[i++] = 0x24;
-		bootstrap[i++] = 4 * 8;
+		bootstrap[i++] = 5 * 8;
 		MoveMemory(bootstrap + i, &flags, sizeof(flags));
 		i += sizeof(flags);
 

--- a/PowerShell/ConvertTo-Shellcode.ps1
+++ b/PowerShell/ConvertTo-Shellcode.ps1
@@ -125,12 +125,12 @@ public class sRDI
             newShellcode.Add(0xec);
             newShellcode.Add(6 * 8); // 32 bytes for shadow space + 8 bytes for last arg + 8 bytes for stack alignment
 
-            // mov qword ptr [rsp + 0x28], rcx (shellcode base) - Push in arg 5
+            // mov qword ptr [rsp + 0x20], rcx (shellcode base) - Push in arg 5
             newShellcode.Add(0x48);
             newShellcode.Add(0x89);
             newShellcode.Add(0x4C);
             newShellcode.Add(0x24);
-            newShellcode.Add(5 * 8);
+            newShellcode.Add(4 * 8);
 
             // Setup the location of the DLL into RCX
             // add rcx, <Offset of the DLL>
@@ -140,11 +140,11 @@ public class sRDI
             foreach (byte b in BitConverter.GetBytes(dllOffset))
                 newShellcode.Add(b);
 
-            // mov dword ptr [rsp + 0x20], <Flags> - Push arg 6 just above shadow space
+            // mov dword ptr [rsp + 0x28], <Flags> - Push arg 6 just above shadow space
             newShellcode.Add(0xc7);
             newShellcode.Add(0x44);
             newShellcode.Add(0x24);
-            newShellcode.Add(4 * 8);
+            newShellcode.Add(5 * 8);
             foreach (byte b in BitConverter.GetBytes((uint)flags))
                 newShellcode.Add(b);
 

--- a/Python/ShellcodeRDI.py
+++ b/Python/ShellcodeRDI.py
@@ -106,17 +106,17 @@ def ConvertToShellcode(dllBytes, functionHash=0x10, userData=b'None', flags=0):
         bootstrap += b'\x48\x83\xec'
         bootstrap += b'\x30' # 32 bytes for shadow space + 16 bytes for last args
 
-        # mov qword ptr [rsp + 0x28], rcx (shellcode base) - Push in arg 5
+        # mov qword ptr [rsp + 0x20], rcx (shellcode base) - Push in arg 5
         bootstrap += b'\x48\x89\x4C\x24'
-        bootstrap += b'\x28'
+        bootstrap += b'\x20'
 
         # add rcx, <Offset of the DLL>
         bootstrap += b'\x48\x81\xc1'
         bootstrap += pack('I', dllOffset)
 
-        # mov dword ptr [rsp + 0x20], <Flags> - Push in arg 6 just above shadow space
+        # mov dword ptr [rsp + 0x28], <Flags> - Push in arg 6 just above shadow space
         bootstrap += b'\xC7\x44\x24'
-        bootstrap += b'\x20'
+        bootstrap += b'\x28'
         bootstrap += pack('I', flags)
 
         # call - Transfer execution to the RDI


### PR DESCRIPTION
Argument 5 and 6 are swapped in the x64 builders causing a really long delay between imports. This PR fixes the DotNet, Native, PowerShell, and Python builders.

Fixes #34 
Fixes #33
Closes #32 (fixes only the python builder)